### PR TITLE
Fix README instructions for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ git clone https://github.com/EngineerDanny/apk-framework-detector
 $ cd apk-framework-detector
 
 # Install dependencies
-$ pip install zipfile36
+# No extra package is required for Python 3 since the script uses the built-in `zipfile` module.
 ```
 
 ## :rocket: Running


### PR DESCRIPTION
## Summary
- clarify that no package installation is required for Python 3

## Testing
- `python -m py_compile main.py`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68419d785408832a96083d02f7b9824e