### PR TITLE
Add framework tests and merge upstream updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Use the checks and tests to detect the major framework used in writing the app.
    - Ionic
    - NativeScript
    - Cordova
+3. Game Frameworks
+   - Unity
+   - Unreal
+   - Libgdx
+   - Expo
+   - Kony
 
 ## :white_check_mark: Requirements
 
@@ -85,7 +91,7 @@ $ git clone https://github.com/EngineerDanny/apk-framework-detector
 $ cd apk-framework-detector
 
 # Install dependencies
-$ pip install zipfile36
+# No extra package is required for Python 3 since the script uses the built-in `zipfile` module.
 ```
 
 ## :rocket: Running
@@ -97,7 +103,15 @@ $ pip install zipfile36
  $`python main.py {app_name.apk}` or `python3 main.py {app_name.apk}`
 
 # Example
- $`python main.py fb.apk` or `python3 main.py fb.apk`
+$`python main.py fb.apk` or `python3 main.py fb.apk`
+```
+
+## :test_tube: Testing
+
+Run the test suite with [pytest](https://docs.pytest.org/).
+
+```bash
+pytest
 ```
 
 ## :memo: License

--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 """
 APK FRAMEWORK DETECTOR
 Author  :   Daniel Agyapong
-Website :   https://engineerdanny.me
-Date    :   February, 2022
+Contributor:   Swarup Saha
+Date    :   2024-12-19
 """
 
 import sys
 import zipfile
+import os
 
 
 class FrameWork:
@@ -14,7 +15,12 @@ class FrameWork:
     REACT_NATIVE = "React Native"
     CORDOVA = "Cordova"
     XAMARIN = "Xamarin"
-    NATIVE = "Native (Java/Kotlin) "
+    NATIVE = "Native (Java/Kotlin)"
+    UNITY = "Unity"
+    UNREAL = "Unreal Engine"
+    LIBGDX = "LibGDX"
+    EXPO = "Expo"
+    KONY = "Kony Visualizer"
 
 
 class Technology:
@@ -48,37 +54,100 @@ tech_list = [
     Technology(
         framework=FrameWork.XAMARIN,
         directories=[
-            "/assemblies/Sikur.Monodroid.dll",
-            "/assemblies/Sikur.dll",
-            "/assemblies/Xamarin.Mobile.dll",
-            "/assemblies/mscorlib.dll",
+            "assemblies/Sikur.Monodroid.dll",
+            "assemblies/Sikur.dll",
+            "assemblies/Xamarin.Mobile.dll",
+            "assemblies/mscorlib.dll",
             "libmonodroid.so",
             "libmonosgen-2.0.so",
+        ]
+    ),
+    Technology(
+        framework=FrameWork.UNITY,
+        directories=[
+            "libunity.so",
+            "assets/bin/Data/Managed/UnityEngine.dll",
+            "assets/bin/Data/Managed/UnityEditor.dll",
+        ]
+    ),
+    Technology(
+        framework=FrameWork.UNREAL,
+        directories=[
+            "libUE4.so",
+            "assets/Unreal/UE4Game/Manifest.xml",
+        ]
+    ),
+    Technology(
+        framework=FrameWork.LIBGDX,
+        directories=[
+            "libgdx.so",
+            "assets/libgdx/lwjgl.so",
+            "assets/libgdx.jar",
+        ]
+    ),
+    Technology(
+        framework=FrameWork.EXPO,
+        directories=[
+            "assets/shell-app.bundle",
+            "assets/expo-manifest.json",
+        ]
+    ),
+    Technology(
+        framework=FrameWork.KONY,
+        directories=[
+            "assets/kony.js",
+            "assets/konyframework.js",
+            "assets/KonyApps/config.json",
         ]
     ),
 ]
 
 input_path = 'input/'
-output_path = 'output'
+
+
+def detect_framework(zip_path):
+    """Return a list of detected frameworks for the given apk/zip."""
+    detected_frameworks = []
+    with zipfile.ZipFile(zip_path, 'r') as zip_object:
+        file_names = zip_object.namelist()
+        for tech in tech_list:
+            if any(
+                any(directory in file_name for file_name in file_names)
+                for directory in tech.directories
+            ):
+                detected_frameworks.append(tech.framework)
+
+        if not detected_frameworks:
+            detected_frameworks.append(FrameWork.NATIVE)
+
+    return detected_frameworks
 
 
 def main():
     app_name = get_app_name()
-    detected_frameworks = []
-    
-    with zipfile.ZipFile(app_name, 'r') as zipObject:
-        file_names = zipObject.namelist()
-        # Uncomment the line below to extract the list of files in the apk to the output directory
-        # zipObject.extractall('output')
-        
-        for tech in tech_list:
-            if any(any(file_name.find(directory) != -1 for file_name in file_names) 
-                   for directory in tech.directories):
-                detected_frameworks.append(tech.framework)
-        
-        if not detected_frameworks:
-            detected_frameworks.append(FrameWork.NATIVE)
-        
+
+    try:
+        detected_frameworks = detect_framework(app_name)
+    except FileNotFoundError:
+        print(f"File {app_name} not found.")
+        return
+    except zipfile.BadZipFile:
+        print(f"{app_name} is not a valid APK or zip file.")
+        return
+
+    print_detection_results(detected_frameworks)
+
+
+def get_app_name():
+    args = sys.argv
+    if len(args) > 1:
+        return os.path.join(input_path, args[1])
+    else:
+        print("Please provide an app name as an argument.\nEg: python main.py app_name.apk")
+        sys.exit(1)
+
+
+def print_detection_results(detected_frameworks):
     if len(detected_frameworks) == 1:
         print(f"App was written in {detected_frameworks[0]}")
     else:
@@ -87,16 +156,6 @@ def main():
             print(f"- {framework}")
 
 
-def get_app_name():
-    args = sys.argv
-    if len(args) > 1:
-        return input_path + args[1]
-    else:
-        print("Please provide an app name as an argument." +
-              "\nEg: python main.py app_name.apk")
-        # exit the program
-        exit()
-
-
-# Run the main function
-main()
+# Run the main function when executed directly
+if __name__ == "__main__":
+    main()

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,22 @@
+import zipfile
+from pathlib import Path
+
+from main import detect_framework, FrameWork
+
+
+def test_flutter_detection(tmp_path: Path):
+    zip_path = tmp_path / "test.apk"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("libflutter.so", "")
+
+    frameworks = detect_framework(str(zip_path))
+    assert FrameWork.FLUTTER in frameworks
+
+
+def test_react_native_detection(tmp_path: Path):
+    zip_path = tmp_path / "react.apk"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("libreactnativejni.so", "")
+
+    frameworks = detect_framework(str(zip_path))
+    assert FrameWork.REACT_NATIVE in frameworks


### PR DESCRIPTION
## Summary
- restore game framework docs and built-in zipfile note
- merge framework detection improvements from upstream
- expose `detect_framework` and keep CLI entry point
- expand test suite with React Native test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68419d703294832ab685455e4db3d874